### PR TITLE
更新 lavas-core-vue 的依赖版本

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "es6-promise": "^4.1.1",
     "express": "^4.0.0",
     "fastclick": "^1.0.6",
-    "lavas-core-vue": "^1.0.3",
+    "lavas-core-vue": "^1.1.5",
     "normalize.css": "^7.0.0",
     "stoppable": "^1.0.4"
   },


### PR DESCRIPTION
有开发者提出 目前依赖的 lavas-core-vue 的版本 `^1.0.3` 太低，最新的是 `1.1.5`。
虽然使用 `^` 可以保证安装到最新的，但毕竟也是从 1.0 升级到了 1.1，所以我想还是修改一下。