### PR TITLE
fix: a bug in ssr mode with serviceworker

### DIFF
--- a/core/entry-client.js
+++ b/core/entry-client.js
@@ -117,7 +117,8 @@ else {
     app = new App();
 
     // if style is ready, start mounting immediately
-    if (!enableAsyncCSS
+    if (ssr
+        || !enableAsyncCSS
         || (enableAsyncCSS && window.STYLE_READY)) {
         window.mountLavas();
     }


### PR DESCRIPTION
 SSR 模式下开启 SW，需要走进这个分支，立即执行 `mount()`
```javascript
// core/entry-client.js

if (ssr
        || !enableAsyncCSS
        || (enableAsyncCSS && window.STYLE_READY)) {
        window.mountLavas();
    }
```